### PR TITLE
Updated membership prices to reflect simpler pricing structure

### DIFF
--- a/core/admin/TransactionAdmin.py
+++ b/core/admin/TransactionAdmin.py
@@ -6,7 +6,8 @@ class TransactionAdmin(ViewableModelAdmin):
     list_display = ("type", "timestamp", "gear", "member", "authorizer", "comments")
     list_filter = ("type",)
     search_fields = (
-        "gear__name",
+        "gear__geartype__name",
+        "gear__gear_data",
         "member__first_name",
         "member__last_name",
         "authorizer__first_name",


### PR DESCRIPTION
You cannot search the SQL database for python class property values. As
a result, trying to search over gear__name was giving a lookup error.
I replaced the this with a search over gear_data and geartype__name.
Behavior is not perfect, since this search does not match value+suffix
pairs, but still works basically.